### PR TITLE
Prefix ID Attributes With an Underscore

### DIFF
--- a/src/main/java/com/rackspace/saml/SamlAssertionProducer.java
+++ b/src/main/java/com/rackspace/saml/SamlAssertionProducer.java
@@ -130,7 +130,7 @@ public class SamlAssertionProducer {
 	private Response createResponse(final DateTime issueDate, Issuer issuer, Status status, Assertion assertion) {
 		ResponseBuilder responseBuilder = new ResponseBuilder();
 		Response response = responseBuilder.buildObject();
-		response.setID(UUID.randomUUID().toString());
+		response.setID("_"+UUID.randomUUID().toString());
 		response.setIssueInstant(issueDate);
 		response.setVersion(SAMLVersion.VERSION_20);
 		response.setIssuer(issuer);
@@ -143,7 +143,7 @@ public class SamlAssertionProducer {
 			                          AttributeStatement attributeStatement) {
 		AssertionBuilder assertionBuilder = new AssertionBuilder();
 		Assertion assertion = assertionBuilder.buildObject();
-		assertion.setID(UUID.randomUUID().toString());
+		assertion.setID("_"+UUID.randomUUID().toString());
 		assertion.setIssueInstant(issueDate);
 		assertion.setSubject(subject);
 		assertion.setIssuer(issuer);


### PR DESCRIPTION
The SAML 2.0 spec states that all ID attributes are of type xsd:ID, which states that they should start with a letter or underscore (http://www.datypic.com/sc/saml2/a-ID-1.html and http://www.datypic.com/sc/xsd/t-xsd_ID.html). Since the UUID generator can generate IDs that sometimes start with a number, it can cause any strict SAML 2.0 implementation to throw errors similar to the below.

```Element '{urn:oasis:names:tc:SAML:2.0:protocol}Response', attribute 'ID': '0f4c5f6f-2935-41fd-96ac-5a560cd6aa1c' is not a valid value of the atomic type 'xs:ID'.```

